### PR TITLE
Adding RMV.de for southern/central Hesse, Germany

### DIFF
--- a/fahrplan2.pro
+++ b/fahrplan2.pro
@@ -124,6 +124,7 @@ HEADERS += \
     src/parser/parser_salzburg_efa.h \
     src/parser/parser_resrobot.h \
     src/parser/parser_finland_matka.h \
+    src/parser/parser_xmlrmvde.h \
     src/models/backends.h
 SOURCES += src/main.cpp \
     src/parser/parser_hafasxml.cpp \
@@ -157,6 +158,7 @@ SOURCES += src/main.cpp \
     src/parser/parser_salzburg_efa.cpp \
     src/parser/parser_resrobot.cpp \
     src/parser/parser_finland_matka.cpp \
+    src/parser/parser_xmlrmvde.cpp \
     src/models/backends.cpp
 
 LIBS += $$PWD/3rdparty/gauss-kruger-cpp/gausskruger.cpp

--- a/src/fahrplan_backend_manager.cpp
+++ b/src/fahrplan_backend_manager.cpp
@@ -45,6 +45,7 @@ QStringList FahrplanBackendManager::getParserList()
     result.append(ParserSalzburgEFA::getName());
     result.append(ParserResRobot::getName());
     result.append(ParserFinlandMatka::getName());
+    result.append(ParserXmlRMVde::getName());
 
     // Make sure the index is in bounds
     if (currentParserIndex > (result.count() - 1) || currentParserIndex < 0) {

--- a/src/fahrplan_parser_thread.cpp
+++ b/src/fahrplan_parser_thread.cpp
@@ -170,6 +170,9 @@ void FahrplanParserThread::run()
         case 15:
             m_parser = new ParserFinlandMatka();
             break;
+        case 16:
+            m_parser = new ParserXmlRMVde();
+            break;
     }
 
     m_name = m_parser->name();

--- a/src/fahrplan_parser_thread.h
+++ b/src/fahrplan_parser_thread.h
@@ -40,6 +40,7 @@
 #include "parser/parser_salzburg_efa.h"
 #include "parser/parser_resrobot.h"
 #include "parser/parser_finland_matka.h"
+#include "parser/parser_xmlrmvde.h"
 
 class FahrplanParserThread : public QThread
 {

--- a/src/parser/parser_xmlrmvde.cpp
+++ b/src/parser/parser_xmlrmvde.cpp
@@ -1,0 +1,31 @@
+#include "parser_xmlrmvde.h"
+
+#include <QNetworkReply>
+
+ParserXmlRMVde::ParserXmlRMVde(QObject *parent) :
+    ParserHafasXml(parent)
+{
+    baseXmlUrl = QLatin1String("http://www.rmv.de/auskunft/bin/jp/query.exe");
+    baseUrl = QLatin1String("http://www.rmv.de/auskunft/bin/jp/query.exe");
+}
+
+void ParserXmlRMVde::parseStationsByName(QNetworkReply *networkReply)
+{
+    const QString data = QString::fromUtf8(networkReply->readAll());
+    const StationsList result = internalParseStationsByName(data);
+    emit stationsResult(result);
+}
+
+QString ParserXmlRMVde::getTrainRestrictionsCodes(int trainrestrictions)
+{
+    Q_UNUSED(trainrestrictions)
+    // TODO should something else get returned?
+    return "1111111111111111";
+}
+
+QStringList ParserXmlRMVde::getTrainRestrictions()
+{
+    QStringList result;
+    result.append(tr("All"));
+    return result;
+}

--- a/src/parser/parser_xmlrmvde.h
+++ b/src/parser/parser_xmlrmvde.h
@@ -1,0 +1,41 @@
+/****************************************************************************
+**
+**  This file is a part of Fahrplan.
+**
+**  This program is free software; you can redistribute it and/or modify
+**  it under the terms of the GNU General Public License as published by
+**  the Free Software Foundation; either version 2 of the License, or
+**  (at your option) any later version.
+**
+**  This program is distributed in the hope that it will be useful,
+**  but WITHOUT ANY WARRANTY; without even the implied warranty of
+**  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+**  GNU General Public License for more details.
+**
+**  You should have received a copy of the GNU General Public License along
+**  with this program.  If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
+#ifndef PARSER_XMLRMVDE_H
+#define PARSER_XMLRMVDE_H
+
+#include "parser_hafasxml.h"
+
+class ParserXmlRMVde : public ParserHafasXml
+{
+    Q_OBJECT
+
+public:
+    explicit ParserXmlRMVde(QObject *parent = 0);
+    static QString getName() { return QString(QLatin1String("%1 (rmv.de)")).arg(tr("Germany, Hesse")); }
+    virtual QString name() { return getName(); }
+    virtual QString shortName() { return QLatin1String("rmv.de"); }
+
+protected:
+    void parseStationsByName(QNetworkReply *networkReply);
+    QStringList getTrainRestrictions();
+    QString getTrainRestrictionsCodes(int trainrestrictions);
+};
+
+#endif // PARSER_XMLRMVDE_H


### PR DESCRIPTION
Adding support for Rhein-Main-Verkehrsverbund (RMV), the transport
network serving the Frankfurt metropolitan area in southern and
central Hesse, Germany.

The implementation is actually quite simple, as RMV uses HAFAS,
inheriting and specializing the existing ParserHafasXml class.