### PR TITLE
Adding railteam.de for DB, SNCF, SNCB, eurostar, NS International, ...

### DIFF
--- a/fahrplan2.pro
+++ b/fahrplan2.pro
@@ -131,6 +131,7 @@ HEADERS += \
     src/parser/parser_finland_matka.h \
     src/parser/parser_london_tfl.h \
     src/parser/parser_xmlrmvde.h \
+    src/parser/parser_railteam.h \
     src/models/backends.h
 
 SOURCES += src/main.cpp \
@@ -167,6 +168,7 @@ SOURCES += src/main.cpp \
     src/parser/parser_finland_matka.cpp \
     src/parser/parser_london_tfl.cpp \
     src/parser/parser_xmlrmvde.cpp \
+    src/parser/parser_railteam.cpp \
     src/models/backends.cpp
 
 LIBS += $$PWD/3rdparty/gauss-kruger-cpp/gausskruger.cpp

--- a/src/fahrplan_backend_manager.cpp
+++ b/src/fahrplan_backend_manager.cpp
@@ -55,6 +55,7 @@ QStringList FahrplanBackendManager::getParserList()
     result.append(ParserFinlandMatka::getName());
     result.append(ParserLondonTfl::getName());
     result.append(ParserXmlRMVde::getName());
+    result.append(ParserRailteam::getName());
 
     // Make sure the index is in bounds
     if (currentParserIndex > (result.count() - 1) || currentParserIndex < 0) {

--- a/src/fahrplan_parser_thread.cpp
+++ b/src/fahrplan_parser_thread.cpp
@@ -181,6 +181,9 @@ void FahrplanParserThread::run()
         case 17:
             m_parser = new ParserXmlRMVde();
             break;
+        case 18:
+            m_parser = new ParserRailteam();
+            break;
     }
 
     m_name = m_parser->name();

--- a/src/fahrplan_parser_thread.h
+++ b/src/fahrplan_parser_thread.h
@@ -42,6 +42,7 @@
 #include "parser/parser_finland_matka.h"
 #include "parser/parser_london_tfl.h"
 #include "parser/parser_xmlrmvde.h"
+#include "parser/parser_railteam.h"
 
 class FahrplanParserThread : public QThread
 {

--- a/src/parser/parser_railteam.cpp
+++ b/src/parser/parser_railteam.cpp
@@ -1,0 +1,49 @@
+/****************************************************************************
+**
+**  This file is a part of Fahrplan.
+**
+**  This program is free software; you can redistribute it and/or modify
+**  it under the terms of the GNU General Public License as published by
+**  the Free Software Foundation; either version 2 of the License, or
+**  (at your option) any later version.
+**
+**  This program is distributed in the hope that it will be useful,
+**  but WITHOUT ANY WARRANTY; without even the implied warranty of
+**  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+**  GNU General Public License for more details.
+**
+**  You should have received a copy of the GNU General Public License along
+**  with this program.  If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
+#include "parser_railteam.h"
+
+ParserRailteam::ParserRailteam(QObject *parent)
+    : ParserHafasBinary(parent)
+{
+    baseXmlUrl = "http://railteam.hafas.de/bin/query.exe";
+    baseSTTableUrl = "http://railteam.hafas.de/bin/stboard.exe/en";
+    baseUrl = "http://railteam.hafas.de/bin/query.exe";
+    baseBinaryUrl = "http://railteam.hafas.de/bin/query.exe/en";
+    STTableMode = 1;
+}
+
+QStringList ParserRailteam::getTrainRestrictions()
+{
+    QStringList result;
+    result.append(tr("All"));
+    result.append(tr("All without ICE, TGV"));
+    return result;
+}
+
+QString ParserRailteam::getTrainRestrictionsCodes(int trainrestrictions)
+{
+    QString trainrestr = "1111111111010000";
+    if (trainrestrictions == 0) {
+        trainrestr = "1111111111010000"; //ALL
+    } else if (trainrestrictions == 1) {
+        trainrestr = "0111111111010000"; //All without ICE, TGV
+    } 
+    return trainrestr;
+}

--- a/src/parser/parser_railteam.h
+++ b/src/parser/parser_railteam.h
@@ -1,0 +1,40 @@
+/****************************************************************************
+**
+**  This file is a part of Fahrplan.
+**
+**  This program is free software; you can redistribute it and/or modify
+**  it under the terms of the GNU General Public License as published by
+**  the Free Software Foundation; either version 2 of the License, or
+**  (at your option) any later version.
+**
+**  This program is distributed in the hope that it will be useful,
+**  but WITHOUT ANY WARRANTY; without even the implied warranty of
+**  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+**  GNU General Public License for more details.
+**
+**  You should have received a copy of the GNU General Public License along
+**  with this program.  If not, see <http://www.gnu.org/licenses/>.
+**
+****************************************************************************/
+
+#ifndef PARSER_RAILTEAM_H
+#define PARSER_RAILTEAM_H
+
+#include "parser_hafasbinary.h"
+
+class ParserRailteam: public ParserHafasBinary
+{
+    Q_OBJECT
+
+public:
+    explicit ParserRailteam(QObject *parent = 0);
+    static QString getName() { return QString("%1 (railteam.eu)").arg(tr("Europe")); }
+    virtual QString name() { return getName(); }
+    virtual QString shortName() { return "railteam.eu"; }
+
+protected:
+    QStringList getTrainRestrictions();
+    QString getTrainRestrictionsCodes(int trainrestrictions);
+};
+
+#endif // PARSER_RAILTEAM_H


### PR DESCRIPTION
Add parser for railteam.de which contains information from DB, SCNF, SNCB, eurostar, NS International, OEBB, SBB.
I closely followd this PR: https://github.com/balcy/fahrplan/pull/6/files. Thanks in advance!